### PR TITLE
Restore the IsVector extension methods and add VectorAttribute annotation

### DIFF
--- a/EFCore.SqlServer.VectorSearch.Test/EFCore.SqlServer.VectorSearch.Test.csproj
+++ b/EFCore.SqlServer.VectorSearch.Test/EFCore.SqlServer.VectorSearch.Test.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />

--- a/EFCore.SqlServer.VectorSearch.Test/VectorSearchQueryTest.cs
+++ b/EFCore.SqlServer.VectorSearch.Test/VectorSearchQueryTest.cs
@@ -109,7 +109,7 @@ WHERE [p].[Id] = 1
         [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public int Id { get; set; }
 
-        [Column(TypeName = "vector(3)")]
+        [Vector(3)]
         public float[] Embedding { get; set; }
     }
 

--- a/EFCore.SqlServer.VectorSearch/Annotations/VectorAttribute.cs
+++ b/EFCore.SqlServer.VectorSearch/Annotations/VectorAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace System.ComponentModel.DataAnnotations.Schema;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+public class VectorAttribute : ColumnAttribute
+{
+    public VectorAttribute(int size = 1536)
+        => TypeName = $"vector({size})";
+
+    public VectorAttribute(string name, int size = 1536) : base(name)
+        => TypeName = $"vector({size})";
+}

--- a/EFCore.SqlServer.VectorSearch/EFCore.SqlServer.VectorSearch.csproj
+++ b/EFCore.SqlServer.VectorSearch/EFCore.SqlServer.VectorSearch.csproj
@@ -10,7 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EFCore.SqlServer.VectorSearch/Extensions/SqlServerVectorSearchPropertyBuilderExtensions.cs
+++ b/EFCore.SqlServer.VectorSearch/Extensions/SqlServerVectorSearchPropertyBuilderExtensions.cs
@@ -1,4 +1,3 @@
-using EFCore.SqlServer.VectorSearch.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 // ReSharper disable once CheckNamespace
@@ -6,11 +5,9 @@ namespace Microsoft.EntityFrameworkCore;
 
 public static class SqlServerVectorSearchPropertyBuilderExtensions
 {
-    [Obsolete("Configure your property to use the 'vector' via HasColumnType()")]
-    public static PropertyBuilder IsVector(this PropertyBuilder propertyBuilder)
-        => throw new NotSupportedException();
+    public static PropertyBuilder IsVector(this PropertyBuilder propertyBuilder, int size = 1536)
+        => propertyBuilder.HasColumnType($"vector({size})");
 
-    [Obsolete("Configure your property to use the 'vector' via HasColumnType()")]
-    public static PropertyBuilder<T> IsVector<T>(this PropertyBuilder<T> propertyBuilder)
-        => throw new NotSupportedException();
+    public static PropertyBuilder<T> IsVector<T>(this PropertyBuilder<T> propertyBuilder, int size = 1536)
+        => propertyBuilder.HasColumnType($"vector({size})");
 }


### PR DESCRIPTION
This PR restores the `IsVector` extension methods, making easier to define a column as Vector. It also add as a `VectorAttribute `annotation to cover also the scenarions that rely on data annotations.

Closes #6 